### PR TITLE
Adjusted default value to rotate mongodb logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,9 @@ mongodb_logrotate_options: |
   {{ mongodb_systemlog_path }} {
     daily
     rotate 7
-    maxsize 1G
+    maxsize 10G
     missingok
     compress
-    delaycompress
     notifempty
     create 640 {{ mongodb_user }} {{ mongodb_user }}
     sharedscripts

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,10 +82,9 @@ mongodb_logrotate_options: |
   {{ mongodb_systemlog_path }} {
     daily
     rotate 7
-    maxsize 1G
+    maxsize 10G
     missingok
     compress
-    delaycompress
     notifempty
     create 640 {{ mongodb_user }} {{ mongodb_user }}
     sharedscripts


### PR DESCRIPTION
Remove delay compress and define maxsize to 10G.