### PR TITLE
Remove to_nice_json from audit config template file

### DIFF
--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -127,7 +127,7 @@ systemLog:
 {% if mongodb_config['auditLog'] is defined -%}
 auditLog:
   {% for key, value in mongodb_config['auditLog'].items() -%}
-  {{ key }}: {{ value | to_nice_json }}
+  {{ key }}: {{ value }}
   {% endfor %}
   {% endif %}
 


### PR DESCRIPTION
Remove to_nice_json to set literal filter in auditlog config.